### PR TITLE
Added support for Docker

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -4,8 +4,6 @@ FROM frolvlad/alpine-go
 RUN apk update && apk upgrade && \
     apk add --no-cache bash git
 
-#ENV GOPATH /root/go
-
 RUN go get github.com/orderbynull/lottip && \
     go get github.com/mjibson/esc && \
     go install github.com/mjibson/esc && \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,25 @@
+FROM frolvlad/alpine-go
+
+
+RUN apk update && apk upgrade && \
+    apk add --no-cache bash git
+
+#ENV GOPATH /root/go
+
+RUN go get github.com/orderbynull/lottip && \
+    go get github.com/mjibson/esc && \
+    go install github.com/mjibson/esc && \
+    cd /root/go/src/github.com/orderbynull/lottip && \
+    /root/go/bin/esc -o fs.go -prefix web -include=".*\.css|.*\.js|.*\.html|.*\.png" web && \
+    go build
+
+ADD run.sh /run.sh
+RUN chmod +x /run.sh
+
+EXPOSE 4041
+EXPOSE 9999
+
+CMD /run.sh
+
+
+

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,24 @@
+#/env/bash
+
+# Set defaults
+
+# IP and port to listen for MySQL
+LOTTIP_PROXY="${LOTTIP_PROXY:-0.0.0.0:4041}"
+
+# IP and port to connect to MySQL 
+LOTTIP_MYSQL="${LOTTIP_MYSQL:-$(/sbin/ip route|awk '/default/ { print $3 }'):3306}"
+
+# IP and port for the GUI to listen to
+LOTTIP_GUI="${LOTTIP_GUI:-0.0.0.0:9999}"
+
+# MySQL DSN (credentials)
+LOTTIP_DSN="${LOTTIP_DSN:-root:root@/}"
+
+
+# Run lottip
+
+/root/go/src/github.com/orderbynull/lottip/lottip \
+  --proxy "$LOTTIP_PROXY" \
+  --mysql "$LOTTIP_MYSQL" \
+  --gui "$LOTTIP_GUI" \
+  --mysql-dsn "$LOTTIP_DSN"


### PR DESCRIPTION
This commit adds support for Docker and can be built automatically on Docker hub.

It will need some added documentation, but it works as it is. Configuration is passed via environment variables through the run.sh script. It works wonderfully as a part of a docker-compose.yml dev environment.
